### PR TITLE
feat: add course-related content types and attributes

### DIFF
--- a/src/api/course-block/content-types/course-block/schema.json
+++ b/src/api/course-block/content-types/course-block/schema.json
@@ -1,0 +1,40 @@
+{
+  "kind": "collectionType",
+  "collectionName": "course_blocks",
+  "info": {
+    "singularName": "course-block",
+    "pluralName": "course-blocks",
+    "displayName": "Course Block",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "Title": {
+      "type": "string"
+    },
+    "Description": {
+      "type": "blocks"
+    },
+    "course": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::course.course",
+      "inversedBy": "course_blocks"
+    },
+    "type": {
+      "type": "enumeration",
+      "enum": [
+        "youtube",
+        "pdf",
+        "ppt"
+      ]
+    },
+    "url": {
+      "type": "uid",
+      "targetField": "Title"
+    }
+  }
+}

--- a/src/api/course-block/controllers/course-block.ts
+++ b/src/api/course-block/controllers/course-block.ts
@@ -1,0 +1,7 @@
+/**
+ * course-block controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::course-block.course-block');

--- a/src/api/course-block/routes/course-block.ts
+++ b/src/api/course-block/routes/course-block.ts
@@ -1,0 +1,7 @@
+/**
+ * course-block router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::course-block.course-block');

--- a/src/api/course-block/services/course-block.ts
+++ b/src/api/course-block/services/course-block.ts
@@ -1,0 +1,7 @@
+/**
+ * course-block service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::course-block.course-block');

--- a/src/api/course-category/content-types/course-category/schema.json
+++ b/src/api/course-category/content-types/course-category/schema.json
@@ -1,0 +1,44 @@
+{
+  "kind": "collectionType",
+  "collectionName": "course_categories",
+  "info": {
+    "singularName": "course-category",
+    "pluralName": "course-categories",
+    "displayName": "Course Category"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "Title": {
+      "type": "string"
+    },
+    "Description": {
+      "type": "richtext"
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "Title"
+    },
+    "Cover": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": false
+    },
+    "DescriptionJSON": {
+      "type": "blocks"
+    },
+    "courses": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::course.course",
+      "mappedBy": "course_category"
+    }
+  }
+}

--- a/src/api/course-category/controllers/course-category.ts
+++ b/src/api/course-category/controllers/course-category.ts
@@ -1,0 +1,7 @@
+/**
+ * course-category controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::course-category.course-category');

--- a/src/api/course-category/routes/course-category.ts
+++ b/src/api/course-category/routes/course-category.ts
@@ -1,0 +1,7 @@
+/**
+ * course-category router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::course-category.course-category');

--- a/src/api/course-category/services/course-category.ts
+++ b/src/api/course-category/services/course-category.ts
@@ -1,0 +1,7 @@
+/**
+ * course-category service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::course-category.course-category');

--- a/src/api/course/content-types/course/schema.json
+++ b/src/api/course/content-types/course/schema.json
@@ -1,0 +1,47 @@
+{
+  "kind": "collectionType",
+  "collectionName": "courses",
+  "info": {
+    "singularName": "course",
+    "pluralName": "courses",
+    "displayName": "Course"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "Title": {
+      "type": "string"
+    },
+    "Description": {
+      "type": "blocks"
+    },
+    "Cover": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": false
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "Title"
+    },
+    "course_category": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::course-category.course-category",
+      "inversedBy": "courses"
+    },
+    "course_blocks": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::course-block.course-block",
+      "mappedBy": "course"
+    }
+  }
+}

--- a/src/api/course/controllers/course.ts
+++ b/src/api/course/controllers/course.ts
@@ -1,0 +1,7 @@
+/**
+ * course controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::course.course');

--- a/src/api/course/routes/course.ts
+++ b/src/api/course/routes/course.ts
@@ -1,0 +1,7 @@
+/**
+ * course router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::course.course');

--- a/src/api/course/services/course.ts
+++ b/src/api/course/services/course.ts
@@ -1,0 +1,7 @@
+/**
+ * course service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::course.course');

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -502,6 +502,112 @@ export interface ApiCategoryCategory extends Struct.CollectionTypeSchema {
   };
 }
 
+export interface ApiCourseBlockCourseBlock extends Struct.CollectionTypeSchema {
+  collectionName: 'course_blocks';
+  info: {
+    description: '';
+    displayName: 'Course Block';
+    pluralName: 'course-blocks';
+    singularName: 'course-block';
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    course: Schema.Attribute.Relation<'manyToOne', 'api::course.course'>;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    Description: Schema.Attribute.Blocks;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::course-block.course-block'
+    > &
+      Schema.Attribute.Private;
+    publishedAt: Schema.Attribute.DateTime;
+    Title: Schema.Attribute.String;
+    type: Schema.Attribute.Enumeration<['youtube', 'pdf', 'ppt']>;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    url: Schema.Attribute.UID<'Title'>;
+  };
+}
+
+export interface ApiCourseCategoryCourseCategory
+  extends Struct.CollectionTypeSchema {
+  collectionName: 'course_categories';
+  info: {
+    displayName: 'Course Category';
+    pluralName: 'course-categories';
+    singularName: 'course-category';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    courses: Schema.Attribute.Relation<'oneToMany', 'api::course.course'>;
+    Cover: Schema.Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    Description: Schema.Attribute.RichText;
+    DescriptionJSON: Schema.Attribute.Blocks;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::course-category.course-category'
+    > &
+      Schema.Attribute.Private;
+    publishedAt: Schema.Attribute.DateTime;
+    slug: Schema.Attribute.UID<'Title'>;
+    Title: Schema.Attribute.String;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface ApiCourseCourse extends Struct.CollectionTypeSchema {
+  collectionName: 'courses';
+  info: {
+    displayName: 'Course';
+    pluralName: 'courses';
+    singularName: 'course';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    course_blocks: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::course-block.course-block'
+    >;
+    course_category: Schema.Attribute.Relation<
+      'manyToOne',
+      'api::course-category.course-category'
+    >;
+    Cover: Schema.Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    Description: Schema.Attribute.Blocks;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::course.course'
+    > &
+      Schema.Attribute.Private;
+    publishedAt: Schema.Attribute.DateTime;
+    slug: Schema.Attribute.UID<'Title'>;
+    Title: Schema.Attribute.String;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
 export interface ApiGlobalGlobal extends Struct.SingleTypeSchema {
   collectionName: 'globals';
   info: {
@@ -1076,6 +1182,9 @@ declare module '@strapi/strapi' {
       'api::article.article': ApiArticleArticle;
       'api::author.author': ApiAuthorAuthor;
       'api::category.category': ApiCategoryCategory;
+      'api::course-block.course-block': ApiCourseBlockCourseBlock;
+      'api::course-category.course-category': ApiCourseCategoryCourseCategory;
+      'api::course.course': ApiCourseCourse;
       'api::global.global': ApiGlobalGlobal;
       'api::translation.translation': ApiTranslationTranslation;
       'plugin::content-releases.release': PluginContentReleasesRelease;


### PR DESCRIPTION
- Introduced new interfaces for Course, Course Block, and Course Category in the contentTypes definition.
- Defined attributes including relations, media, and localization options for each new type.
- Updated the Strapi module declaration to include the new content types.